### PR TITLE
Remove gplus from amp-social-share

### DIFF
--- a/amp-pwa/content/1.amp.html
+++ b/amp-pwa/content/1.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/10.amp.html
+++ b/amp-pwa/content/10.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/11.amp.html
+++ b/amp-pwa/content/11.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/12.amp.html
+++ b/amp-pwa/content/12.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/13.amp.html
+++ b/amp-pwa/content/13.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/14.amp.html
+++ b/amp-pwa/content/14.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/15.amp.html
+++ b/amp-pwa/content/15.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/16.amp.html
+++ b/amp-pwa/content/16.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/17.amp.html
+++ b/amp-pwa/content/17.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/18.amp.html
+++ b/amp-pwa/content/18.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/19.amp.html
+++ b/amp-pwa/content/19.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/2.amp.html
+++ b/amp-pwa/content/2.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/20.amp.html
+++ b/amp-pwa/content/20.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/21.amp.html
+++ b/amp-pwa/content/21.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/22.amp.html
+++ b/amp-pwa/content/22.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/23.amp.html
+++ b/amp-pwa/content/23.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/24.amp.html
+++ b/amp-pwa/content/24.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/25.amp.html
+++ b/amp-pwa/content/25.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/26.amp.html
+++ b/amp-pwa/content/26.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/27.amp.html
+++ b/amp-pwa/content/27.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/28.amp.html
+++ b/amp-pwa/content/28.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/29.amp.html
+++ b/amp-pwa/content/29.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/3.amp.html
+++ b/amp-pwa/content/3.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/30.amp.html
+++ b/amp-pwa/content/30.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/4.amp.html
+++ b/amp-pwa/content/4.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/5.amp.html
+++ b/amp-pwa/content/5.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/6.amp.html
+++ b/amp-pwa/content/6.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/7.amp.html
+++ b/amp-pwa/content/7.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/8.amp.html
+++ b/amp-pwa/content/8.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>

--- a/amp-pwa/content/9.amp.html
+++ b/amp-pwa/content/9.amp.html
@@ -202,7 +202,6 @@
     <div>
       <amp-social-share type="twitter" width="45" height="33"></amp-social-share>
       <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610></amp-social-share>
-      <amp-social-share type="gplus" width="45" height="33"></amp-social-share>
       <amp-social-share type="pinterest" width="45" height="33"></amp-social-share>
       <amp-social-share type="email" width="45" height="33"></amp-social-share>
     </div>


### PR DESCRIPTION
Fixes: #213 

Removes the Google+ sharing capability from each sample that has the amp-social-share component.