### PR TITLE
Optimize AMP

### DIFF
--- a/amp-camp/package.json
+++ b/amp-camp/package.json
@@ -10,9 +10,11 @@
   "author": "Ben Morss",
   "license": "Apache-2.0",
   "dependencies": {
+    "amp-toolbox-optimizer": "^1.2.0-alpha.0",
     "amphtml-autoscript": "1.5.0",
     "amphtml-validator": "^1.0.23",
     "browser-sync": "^2.26.3",
+    "client-sessions": "^0.8.0",
     "del": "^3.0.0",
     "express": "^4.16.3",
     "express-formidable": "^1.2.0",
@@ -28,12 +30,11 @@
     "jsdom": "^11.12.0",
     "mustache-express": "^1.2.7",
     "request": "^2.88.0",
+    "serialize-to-js": "^1.2.2",
     "through2": "^2.0.5",
     "uglify-es": "^3.3.10",
     "workbox-build": "^3.6.3",
-    "workbox-sw": "^3.6.3",
-    "client-sessions": "^0.8.0",
-    "serialize-to-js": "^1.2.2"
+    "workbox-sw": "^3.6.3"
   },
   "devDependencies": {
     "gulp": "github:gulpjs/gulp",

--- a/amp-camp/src/html/pages/product-details.html
+++ b/amp-camp/src/html/pages/product-details.html
@@ -5,7 +5,6 @@
     %%include('../partials/head.html', {
         "pageType": "product-details"
     })
-    <link rel="preload" href="/api/product?productId=<%Main_Id%>&ampList=true" as="fetch">
 </head>
 <body [class]="cart.added ? 'cart-added' : ''">
     %%include('../partials/header.html', {

--- a/amp-camp/src/html/pages/product-listing.html
+++ b/amp-camp/src/html/pages/product-listing.html
@@ -5,7 +5,6 @@
     %%include('../partials/head.html', {
         "pageType": "product-listing"
     })
-    <link rel="preload" href="/api/categories?categoryId=<%productsGender%>-<%productsCategory%>&sort=high-low" as="fetch">
 </head>
 <body>
     %%include('../partials/header.html', {

--- a/amp-camp/src/server/server.js
+++ b/amp-camp/src/server/server.js
@@ -7,8 +7,15 @@ const mustache = require("mustache");
 const formidableMiddleware = require('express-formidable');
 const sessions = require("client-sessions");
 const serializer = require('serialize-to-js');
+const ampOptimizer = require('amp-toolbox-optimizer');
 const apiManager = new productApiManager();
 
+// a simple in-memory response cache
+const cache = new Map();
+
+ampOptimizer.setConfig({
+  validAmp: true,
+});
 
 /** LIST OF STATIC URLS FOR STATIC PAGES **/
 
@@ -50,19 +57,48 @@ const listener = app.listen(port, () => {
 
 /** HANDLERS FOR STATIC PAGES AND STATIC FILES **/
 
+// Optimize and cache HTML responses
+app.use(function(req, res, next) {
+  if (req.method != 'GET' || !req.accepts('text/html')) {
+    return next();
+  }
+  // Set max-age to 1 min
+  res.set('Cache-Control', 'max-age=60');
+  let key = req.originalUrl;
+  // Check if there's a cached response
+  let cachedBody = cache.get(key);
+  if (cachedBody) {
+    // console.log('[cache hit]', key);
+    res.send(cachedBody)
+    return
+  } 
+  const oldSend = res.send;
+  res.send = function() {
+    ampOptimizer.transformHtml(arguments[0]).then(transformed => {
+      // console.log('[cache miss]', key);
+      // rewrite body to optimized AMP version
+      arguments[0] = transformed;
+      // cache the response (we assume a limited number of pages fitting into memory)
+      cache.set(key, transformed);
+      oldSend.apply(this, arguments);
+    });
+  }
+  next()
+});
+
 //Intercepts all requests:
 //If the request is for a static page, calls 'renderPage', passing the page's template, so the 'canonical' tag can be inserted, before rendering the page.
 //Otherwise, calls next(), so another handler can process the request.
-app.use("*", function(req, res, next) {
+app.use(function(req, res, next) {
 
     let originalUrl = req.originalUrl;
 
     if(req.method === 'GET' && staticPageUrls.includes(originalUrl)) {
-        let templateName = getTemplateForUrl(originalUrl);
-        renderPage(req, res, templateName);
-    } else {
-        next();
+      let templateName = getTemplateForUrl(originalUrl);
+      renderPage(req, res, templateName);
+      return;
     }
+    next();
 });
 
 //Serves static files
@@ -307,7 +343,6 @@ app.get('/api/related-products', function(req, res) {
     });
 });
 
-
 /** HELPERS **/
 
 // If the session contains a cart, then deserialize it and return that!
@@ -356,11 +391,7 @@ function enableCors(req, res) {
 
 //Receives a template for a page to render. If it's a dynamic page, will receive a JSON object, otherwise, will create and empty one.
 //Declares the tags that will be used by mustache, and defines the 'CanonicalLink' variable, so it can be injected int the canonical tag.
-function renderPage(req, res, template, responseJsonObj) {
-    if(!responseJsonObj) {
-        responseJsonObj = {}
-    }
-    
+function renderPage(req, res, template, responseJsonObj={}) {
     let fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
     responseJsonObj.CanonicalLink = fullUrl;
 


### PR DESCRIPTION
This commit adds a middleware that optimizes all HTML responses using
AMP Optimizers brand-new valid optimized AMP mode. To avoid slower
server-responses, I've also added a simple in memory page cache.

Sidenote: I've removed the amp-list src preloads as these don't work.