### PR TITLE
Using amp-toolbox-cors to configure CORS for the site.

### DIFF
--- a/amp-camp/package.json
+++ b/amp-camp/package.json
@@ -10,9 +10,11 @@
   "author": "Ben Morss",
   "license": "Apache-2.0",
   "dependencies": {
+    "amp-toolbox-cors": "^0.2.5",
     "amphtml-autoscript": "1.5.0",
     "amphtml-validator": "^1.0.23",
     "browser-sync": "^2.26.3",
+    "client-sessions": "^0.8.0",
     "del": "^3.0.0",
     "express": "^4.16.3",
     "express-formidable": "^1.2.0",
@@ -28,12 +30,11 @@
     "jsdom": "^11.12.0",
     "mustache-express": "^1.2.7",
     "request": "^2.88.0",
+    "serialize-to-js": "^1.2.2",
     "through2": "^2.0.5",
     "uglify-es": "^3.3.10",
     "workbox-build": "^3.6.3",
-    "workbox-sw": "^3.6.3",
-    "client-sessions": "^0.8.0",
-    "serialize-to-js": "^1.2.2"
+    "workbox-sw": "^3.6.3"
   },
   "devDependencies": {
     "gulp": "github:gulpjs/gulp",

--- a/amp-camp/src/server/server.js
+++ b/amp-camp/src/server/server.js
@@ -7,6 +7,8 @@ const mustache = require("mustache");
 const formidableMiddleware = require('express-formidable');
 const sessions = require("client-sessions");
 const serializer = require('serialize-to-js');
+const ampCors = require('amp-toolbox-cors');
+
 const apiManager = new productApiManager();
 
 
@@ -30,6 +32,16 @@ app.use(sessions({
     secret: 'eommercedemoofamazigness',
     duration: 24 * 60 * 60 * 1000,
     activeDuration: 1000 * 60 * 5
+}));
+
+//Configure amp-toolbox-cors for CORS.
+//Appengine will set the environment to 'production', if so: add the site domain, otherwise, leave it out, so localhost can be used.
+let sourceOriginPattern = null;
+if (app.get('env') === 'production') {
+   sourceOriginPattern = /https:\/\/camp\.samples\.amp\.dev$/
+}
+app.use(ampCors({
+   sourceOriginPattern,
 }));
 
 app.engine('html', function(filePath, options, callback) {
@@ -178,7 +190,6 @@ app.post('/api/add-to-cart', function(req, res) {
         res.header("AMP-Redirect-To", origin + "/shopping-cart");
     }
 
-    enableCors(req, res);
     //amp-form requires json response
     res.json({});
 });
@@ -244,7 +255,6 @@ app.get('/api/cart-items', function(req, res) {
 
     let response = { items: [cart] };
 
-    enableCors(req, res);
     res.send(response);
 });
 
@@ -253,7 +263,6 @@ app.get('/api/cart-count', function(req, res) {
 
     let response = { items: [{ count: cart.cartItems.length }] };
 
-    enableCors(req, res);
     res.send(response);
 });
 
@@ -274,7 +283,6 @@ app.post('/api/delete-cart-item', function(req, res) {
         shoppingCartResponse.items.push(shoppingCart);
     }
 
-    enableCors(req, res);
     res.send(shoppingCartResponse);
 });
 
@@ -336,19 +344,6 @@ function updateShoppingCartOnSession(req, productId, categoryId, name, price, co
 
     shoppingCartObj.addItem(cartProduct);
     req.session.shoppingCart = serializer.serialize(shoppingCartObj);
-}
-
-function enableCors(req, res) {
-
-    //set to all for dev purposes only, change it by configuration to final domain
-    let sourceOrigin = req.query.__amp_source_origin;
-    let origin = req.get('origin') || sourceOrigin;
-
-    res.header('Access-Control-Allow-Credentials', 'true');
-    res.header("Access-Control-Allow-Origin", origin);
-    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    res.header("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin,AMP-Redirect-To");
-    res.header("AMP-Access-Control-Allow-Source-Origin", sourceOrigin);
 }
 
 //Receives a template for a page to render. If it's a dynamic page, will receive a JSON object, otherwise, will create and empty one.


### PR DESCRIPTION
This PR should replace #217.

Using [amp-toolbox-cors](https://www.npmjs.com/package/amp-toolbox-cors) to configure CORS of the site:

If the environment is 'production' we use the Regexp: /https:\/\/camp\.samples\.amp\.dev$/.
Otherwise, we leave sourceOriginPattern as null, so localhost can be accepted.

Please, make sure to test in GCP.

cc // @sebastianbenz 