### PR TITLE
Migrate to AMP Optimizer 2.0

### DIFF
--- a/amp-camp/package.json
+++ b/amp-camp/package.json
@@ -10,9 +10,8 @@
   "author": "Ben Morss",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/toolbox-optimizer": "1.1.2",
+    "@ampproject/toolbox-optimizer": "2.0.0-alpha.3",
     "@ampproject/toolbox-cors": "1.1.1",
-    "amphtml-autoscript": "1.5.2",
     "amphtml-validator": "^1.0.29",
     "browser-sync": "^2.26.7",
     "client-sessions": "^0.8.0",

--- a/amp-camp/src/html/pages/product-details.html
+++ b/amp-camp/src/html/pages/product-details.html
@@ -19,75 +19,75 @@
         </script>
     </amp-state>
     <main id="content" role="main" class="main product-details">
-        <amp-state id="product" src="/api/product?productId=<%Main_Id%>&ampList=true">
+        <amp-state id="product" src="/api/product?productId=[%Main_Id%]&ampList=true">
         <script type="application/json">
         {
-            "selectedColor": "<%DefaultColor%>",
-            "selectedSize": "<%DefaultSize%>",
+            "selectedColor": "[%DefaultColor%]",
+            "selectedSize": "[%DefaultSize%]",
             "selectedQuantity": 1,
-            <%#All_Colors%>
-                "<%ColorName%>": {
+            [%#All_Colors%]
+                "[%ColorName%]": {
                     "sizes" : {
-                        <%#Avaliable_Sizes%>
-                            <%#available%>
-                                <%#Last%>
-                                    "<%SizeName%>": {
-                                        "discountPrice" : "<%Discount_Price%>",
-                                        "stock" : "<%Stock%>"
+                        [%#Avaliable_Sizes%]
+                            [%#available%]
+                                [%#Last%]
+                                    "[%SizeName%]": {
+                                        "discountPrice" : "[%Discount_Price%]",
+                                        "stock" : "[%Stock%]"
                                     }
-                                <%/Last%>
-                                <%^Last%>
-                                    "<%SizeName%>": {
-                                        "discountPrice" : "<%Discount_Price%>",
-                                        "stock" : "<%Stock%>"
+                                [%/Last%]
+                                [%^Last%]
+                                    "[%SizeName%]": {
+                                        "discountPrice" : "[%Discount_Price%]",
+                                        "stock" : "[%Stock%]"
                                     },
-                                <%/Last%>
-                            <%/available%>
-                        <%/Avaliable_Sizes%>
+                                [%/Last%]
+                            [%/available%]
+                        [%/Avaliable_Sizes%]
                     },
-                    "stock" : "<%Stock%>",
-                    "defaultSize" : "<%DefaultSize%>",
+                    "stock" : "[%Stock%]",
+                    "defaultSize" : "[%DefaultSize%]",
                     "thumb": {
-                        "image1": "<%& Photo%>",
-                        "image2": "<%& Photo%>",
-                        "image3": "<%& Photo%>"
+                        "image1": "[%& Photo%]",
+                        "image2": "[%& Photo%]",
+                        "image3": "[%& Photo%]"
                     },
                     "large": {
-                        "image1": "<%& Photo%>",
-                        "image2": "<%& Photo%>",
-                        "image3": "<%& Photo%>"
+                        "image1": "[%& Photo%]",
+                        "image2": "[%& Photo%]",
+                        "image3": "[%& Photo%]"
                     },
-                    "option":"<%option%>"
+                    "option":"[%option%]"
                 },
-                "<%& option%>": "<%ColorName%>",
-            <%/All_Colors%>
+                "[%& option%]": "[%ColorName%]",
+            [%/All_Colors%]
             "selectedSlide": 0
         }
         </script>
         </amp-state>
 
         <section class="details-content flex flex-wrap">
-            <%#UniqueColor%>
-                <%#All_Colors%>
+            [%#UniqueColor%]
+                [%#All_Colors%]
                 <div class="single-product">
-                    <amp-img src="<%& Photo%>" width="1280" height="720" alt="product image" layout="responsive">
+                    <amp-img src="[%& Photo%]" width="1280" height="720" alt="product image" layout="responsive">
                         <div placeholder="" class="loading"></div>
                     </amp-img>
                 </div>
-                <%/All_Colors%>
-            <%/UniqueColor%>
-            <%^UniqueColor%>
+                [%/All_Colors%]
+            [%/UniqueColor%]
+            [%^UniqueColor%]
             <div class="product-carousel">
                 <amp-carousel id="main-carousel" width="1280" height="720" layout="responsive" type="slides" [slide]="product.selectedSlide" 
                 on="slideChange: AMP.setState({product: {
                     selectedSlide: event.index,
                     selectedColor: product[event.index + 1]
                 }})">
-                    <%#All_Colors%>
-                    <amp-img src="<%& Photo%>" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
+                    [%#All_Colors%]
+                    <amp-img src="[%& Photo%]" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
                         <div placeholder="" class="loading"></div>
                     </amp-img>
-                    <%/All_Colors%>
+                    [%/All_Colors%]
                 </amp-carousel>
 
                 <amp-selector name="color" layout="container" [selected]="product.selectedColor" 
@@ -99,26 +99,26 @@
                     selectedQuantity: 1
                 }})">
                     <ul>
-                        <%#All_Colors%>
+                        [%#All_Colors%]
                         <li>
-                            <%#defaultColour%>
-                            <amp-img option="<%ColorName%>" src="<%& Photo%>" height="48.5" width="45" selected="selected"></amp-img>
-                            <%/defaultColour%>
-                            <%^defaultColour%>
-                            <amp-img option="<%ColorName%>" src="<%& Photo%>" height="48.5" width="45"></amp-img>
-                            <%/defaultColour%>
+                            [%#defaultColour%]
+                            <amp-img option="[%ColorName%]" src="[%& Photo%]" height="48.5" width="45" selected="selected"></amp-img>
+                            [%/defaultColour%]
+                            [%^defaultColour%]
+                            <amp-img option="[%ColorName%]" src="[%& Photo%]" height="48.5" width="45"></amp-img>
+                            [%/defaultColour%]
                         </li>
-                        <%/All_Colors%>
+                        [%/All_Colors%]
                     </ul>
                 </amp-selector>
             </div>
-            <%/UniqueColor%>
+            [%/UniqueColor%]
 
             <div class="parameters-content flex flex-wrap">
                 <div class="product-description self-start">
-                    <h1><%Product_Title%></h1>
+                    <h1>[%Product_Title%]</h1>
                     <div class="title" [text]="'$' + product[product.selectedColor].sizes[product.selectedSize].discountPrice">&nbsp;
-                        <amp-list src="/api/product?productId=<%Main_Id%>&ampList=true" layout="fill" binding="no" single-item>
+                        <amp-list src="/api/product?productId=[%Main_Id%]&ampList=true" layout="fill" binding="no" single-item>
                             <template type="amp-mustache">
                                 {{#DefaultPrice}}
                                     ${{DefaultPrice}}
@@ -127,22 +127,22 @@
                                     <span class="out-of-stock">Out of stock</span>
                                 {{/DefaultPrice}}
                             </template>
-                            <div placeholder>$<%DefaultPrice%></div>
+                            <div placeholder>$[%DefaultPrice%]</div>
                         </amp-list>
                     </div>
                 </div>
                 <div class="product-rating self-start">
-                    <h2>Reviews (<%ReviewCount%>)</h2>
-                    <%#ReviewFullStars %>
+                    <h2>Reviews ([%ReviewCount%])</h2>
+                    [%#ReviewFullStars %]
                     <svg viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="icon-star">
                         <path fill="currentColor" d="M12.6229508 19.2631579L20.4491803 24l-2.0827869-8.9052632 6.8795082-5.93684206L16.157377 8.4 12.6229508 0 9.0885246 8.4 0 9.15789474l6.8795082 5.99999996L4.7967213 24"></path>
                     </svg>
-                    <%/ReviewFullStars %>
-                    <%#ReviewEmptyStars %>
+                    [%/ReviewFullStars %]
+                    [%#ReviewEmptyStars %]
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon-star-empty" width="26" height="24" viewbox="0 0 26 24">
                         <path fill="currentColor" d="M26 9.15789474L16.911475 8.4 13.377049 0 9.842623 8.4l-9.088525.75789474 6.879509 5.99999996L5.55082 24l7.826229-4.7368421L21.203279 24l-2.082787-8.9052632L26 9.15789474zM13.377049 16.9263158l-4.733606 2.8421053 1.262295-5.431579-4.228689-3.6 5.554099-.5052632 2.145901-5.11578943 2.145902 5.11578943 5.554098.5052632L16.911475 14.4l1.262295 5.4315789-4.796721-2.9052631z"></path>
                     </svg>
-                    <%/ReviewEmptyStars %>
+                    [%/ReviewEmptyStars %]
                 </div>
                 <hr />
                 <form id="order" method="POST" action-xhr="/api/add-to-cart" target="_top" class="flex flex-wrap">
@@ -157,16 +157,16 @@
                             selectedQuantity: 1
                         }})">
                             <ul>
-                                <%#All_Colors%>
+                                [%#All_Colors%]
                                 <li>
-                                    <%#defaultColour%>
-                                    <amp-img option="<%ColorName%>" selected="selected" src="<%& Swatch%>" height="16" width="27"></amp-img>
-                                    <%/defaultColour%>
-                                    <%^defaultColour%>
-                                    <amp-img option="<%ColorName%>" src="<%& Swatch%>" height="16" width="27"></amp-img>
-                                    <%/defaultColour%>
+                                    [%#defaultColour%]
+                                    <amp-img option="[%ColorName%]" selected="selected" src="[%& Swatch%]" height="16" width="27"></amp-img>
+                                    [%/defaultColour%]
+                                    [%^defaultColour%]
+                                    <amp-img option="[%ColorName%]" src="[%& Swatch%]" height="16" width="27"></amp-img>
+                                    [%/defaultColour%]
                                 </li>
-                                <%/All_Colors%>
+                                [%/All_Colors%]
                             </ul>
                         </amp-selector>
                     </div>
@@ -174,19 +174,19 @@
                         <div class="select-container">
                             <label for="sizes" class="title">Select a size: </label>
                             <amp-selector name="size" class="title" layout="container" on="select:AMP.setState({ product: {selectedSize:event.targetOption, selectedQuantity:1}})" [selected]="(product[product.selectedColor].sizes[product.selectedSize] != null) ? product.selectedSize : product[product.selectedColor].defaultSize">
-                                <%#All_Colors.0.Avaliable_Sizes%>
-                                <%#available%>
-                                <%#default%>
-                                <button type="button" option="<%SizeName%>" class="" [class]="(product[product.selectedColor].sizes['<%SizeName%>'] != null)? '' : 'unavailable'" selected><%SizeName%></button>
-                                <%/default%>
-                                <%^default%>
-                                <button type="button" option="<%SizeName%>" class="" [class]="(product[product.selectedColor].sizes['<%SizeName%>'] != null)? '' : 'unavailable'"><%SizeName%></button>
-                                <%/default%>
-                                <%/available%>
-                                <%^available%>
-                                <button type="button" option="<%SizeName%>" option="<%SizeName%>" class="unavailable" [class]="(product[product.selectedColor].sizes['<%SizeName%>'] != null)? '' : 'unavailable'"><%SizeName%></button>
-                                <%/available%>
-                                <%/All_Colors.0.Avaliable_Sizes%>
+                                [%#All_Colors.0.Avaliable_Sizes%]
+                                [%#available%]
+                                [%#default%]
+                                <button type="button" option="[%SizeName%]" class="" [class]="(product[product.selectedColor].sizes['[%SizeName%]'] != null)? '' : 'unavailable'" selected>[%SizeName%]</button>
+                                [%/default%]
+                                [%^default%]
+                                <button type="button" option="[%SizeName%]" class="" [class]="(product[product.selectedColor].sizes['[%SizeName%]'] != null)? '' : 'unavailable'">[%SizeName%]</button>
+                                [%/default%]
+                                [%/available%]
+                                [%^available%]
+                                <button type="button" option="[%SizeName%]" option="[%SizeName%]" class="unavailable" [class]="(product[product.selectedColor].sizes['[%SizeName%]'] != null)? '' : 'unavailable'">[%SizeName%]</button>
+                                [%/available%]
+                                [%/All_Colors.0.Avaliable_Sizes%]
                             </amp-selector>
                         </div>
                     </div>
@@ -195,20 +195,20 @@
                         <div>    
                             <span class="title">Quantity:</span> 
                             <span class="quantity-text" [text]="'(' + product[product.selectedColor].sizes[product.selectedSize].stock + ' Available)'">
-                                <amp-list src="/api/product?productId=<%Main_Id%>&ampList=true" layout="fill" binding="no" single-item>
+                                <amp-list src="/api/product?productId=[%Main_Id%]&ampList=true" layout="fill" binding="no" single-item>
                                     <template type="amp-mustache">({{All_Colors.0.Avaliable_Sizes.0.Stock}} Available)</template>
-                                    <div placeholder>(<%All_Colors.0.Avaliable_Sizes.0.Stock%> Available)</div>
+                                    <div placeholder>([%All_Colors.0.Avaliable_Sizes.0.Stock%] Available)</div>
                                 </amp-list>
                             </span>
                             <div class="buttons-group">
                                 <button type="button" class="button button-white no-transition" [disabled]="product.selectedQuantity == 1" disabled on="tap:AMP.setState({ product: {selectedQuantity : product.selectedQuantity - 1} })">-</button>
                                 <input type="text" class="title" value="1" name="quantity" width="5" height="1" [value]="product.selectedQuantity" readonly>
-                                <%#DefaultQuantityDisabled%>
+                                [%#DefaultQuantityDisabled%]
                                     <button type="button" class="button button-white no-transition" [disabled]="product[product.selectedColor].sizes[product.selectedSize].stock == product.selectedQuantity" disabled on="tap:AMP.setState({ product: {selectedQuantity : (product.selectedQuantity + 1) } })">+</button>
-                                <%/DefaultQuantityDisabled%>
-                                <%^DefaultQuantityDisabled%>
+                                [%/DefaultQuantityDisabled%]
+                                [%^DefaultQuantityDisabled%]
                                     <button type="button" class="button button-white no-transition" [disabled]="product[product.selectedColor].sizes[product.selectedSize].stock == product.selectedQuantity" on="tap:AMP.setState({ product: {selectedQuantity : (product.selectedQuantity + 1) } })">+</button>
-                                <%/DefaultQuantityDisabled%>
+                                [%/DefaultQuantityDisabled%]
                                 <br>
                             </div>
                         </div>
@@ -216,11 +216,11 @@
                     <br />
                     <div class="button-wrapper">
                         <input type="submit" class="cart-actions button button-white" name="add-to-cart" value="add to cart">
-                        <input type="hidden" name="productId" value="<%Main_Id%>">
-                        <input type="hidden" name="categoryId" value="<%CategoryId%>">
-                        <input type="hidden" name="name" value="<%Product_Title%>">
-                        <input type="hidden" name="price" value="<%DefaultPrice%>" [value]="product[product.selectedColor].sizes[product.selectedSize].discountPrice">
-                        <input type="hidden" name="imgUrl" value="<%& All_Colors.0.Photo%>" [value]="product[product.selectedColor].large.image1">
+                        <input type="hidden" name="productId" value="[%Main_Id%]">
+                        <input type="hidden" name="categoryId" value="[%CategoryId%]">
+                        <input type="hidden" name="name" value="[%Product_Title%]">
+                        <input type="hidden" name="price" value="[%DefaultPrice%]" [value]="product[product.selectedColor].sizes[product.selectedSize].discountPrice">
+                        <input type="hidden" name="imgUrl" value="[%& All_Colors.0.Photo%]" [value]="product[product.selectedColor].large.image1">
                     </div>
                     <hr class="section-divider" />
                 </form>
@@ -230,7 +230,7 @@
                 <div class="product-copy">
                     <section>
                         <h2>Overview</h2>
-                        <p><%Description%></p>
+                        <p>[%Description%]</p>
                         <hr />
                     </section>
                 </div>

--- a/amp-camp/src/html/pages/product-listing.html
+++ b/amp-camp/src/html/pages/product-listing.html
@@ -15,13 +15,13 @@
         <amp-state id="products">
             <script type="application/json">
             {
-                "gender": "<%productsGender%>",
-                "category": "<%productsCategory%>",
+                "gender": "[%productsGender%]",
+                "category": "[%productsCategory%]",
                 "filter": "high-low"
             }
             </script>
         </amp-state>
-        <amp-img class="banner xs-hide sm-hide" src="img/<%productsGender%>-extra-wide.jpg" [src]="'img/'+products.gender+'-extra-wide.jpg'" width="3.5" height="1" layout="responsive" alt="Product listing" noloading="">
+        <amp-img class="banner xs-hide sm-hide" src="img/[%productsGender%]-extra-wide.jpg" [src]="'img/'+products.gender+'-extra-wide.jpg'" width="3.5" height="1" layout="responsive" alt="Product listing" noloading="">
             <div placeholder="" class="loading"></div>
         </amp-img>
         <section class="listing-content">
@@ -33,21 +33,21 @@
                                       on="select:AMP.setState({products:{gender: event.targetOption}}), 
                                           products-list.changeToLayoutContainer()"
                                       [selected]="products.gender">
-                            <%#womenSelected%>
+                            [%#womenSelected%]
                             <button type="button" option="women" selected>Women</button>
                             <button type="button" option="men" >Men</button>
-                            <%/womenSelected%>
-                            <%^womenSelected%>
+                            [%/womenSelected%]
+                            [%^womenSelected%]
                             <button type="button" option="women" >Women</button>
                             <button type="button" option="men" selected>Men</button>
-                            <%/womenSelected%>
+                            [%/womenSelected%]
                         </amp-selector> 
                 </div>
             </div>
 
             <div class="listing-container">
                 <div class="listing-header">
-                    <h1 [text]="products.gender+'’s Clothing'"><%productsGender%>’s Clothing</h1>
+                    <h1 [text]="products.gender+'’s Clothing'">[%productsGender%]’s Clothing</h1>
                     <div class="listing-filters">
                         <div class="select-wrapper md-hide lg-hide">
                             <div class="title">
@@ -57,18 +57,18 @@
                                               on="select:AMP.setState({products:{category: event.targetOption}}),
                                                   products-list.changeToLayoutContainer()"
                                               [selected]="products.category">
-                                    <%#shirtSelected%>
+                                    [%#shirtSelected%]
                                     <button type="button" option="shirts" selected>Shirts</button>
-                                    <%/shirtSelected%>
-                                    <%^shirtSelected%>
+                                    [%/shirtSelected%]
+                                    [%^shirtSelected%]
                                     <button type="button" option="shirts">Shirts</button>
-                                    <%/shirtSelected%>
-                                    <%#shortSelected%>
+                                    [%/shirtSelected%]
+                                    [%#shortSelected%]
                                     <button type="button" option="shorts" selected>Shorts</button>
-                                    <%/shortSelected%>
-                                    <%^shortSelected%>
+                                    [%/shortSelected%]
+                                    [%^shortSelected%]
                                     <button type="button" option="shorts" >Shorts</button>
-                                    <%/shortSelected%>
+                                    [%/shortSelected%]
                                 </amp-selector> 
                             </div>
                         </div>
@@ -83,13 +83,13 @@
                 </div>
                 <amp-list id="products-list"
                           [src]="'/api/categories?categoryId=' + products.gender + '-' + products.category + '&sort=' + products.filter"
-                          src="/api/categories?categoryId=<%productsGender%>-<%productsCategory%>&sort=high-low"
+                          src="/api/categories?categoryId=[%productsGender%]-[%productsCategory%]&sort=high-low"
                           height="1000" width="300"
                           layout="responsive"
                           binding="no"
                 >
                     <template type="amp-mustache">
-                        <a href="product-details?categoryId=<%productsGender%>-<%productsCategory%>&productId={{productId}}"
+                        <a href="product-details?categoryId=[%productsGender%]-[%productsCategory%]&productId={{productId}}"
                            target="_self"
                            class="listing-product"
                            [href]="'product-details?categoryId=' + products.gender + '-' + products.category + '&productId={{productId}}'"

--- a/amp-camp/src/html/partials/head.html
+++ b/amp-camp/src/html/partials/head.html
@@ -1,12 +1,7 @@
-<meta charset="utf-8">
 <title>cAMPmor - AMP e-commerce demo</title>
 
-<link rel="canonical" href="<%&CanonicalLink%>">
-<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+<link rel="canonical" href="[%&CanonicalLink%]">
 <meta name="amp-google-client-id-api" content="googleanalytics">
-
-<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-
 
 ${ampjs}
 

--- a/amp-camp/src/html/partials/related-products.html
+++ b/amp-camp/src/html/partials/related-products.html
@@ -1,15 +1,15 @@
-<%#Main_Id%>
+[%#Main_Id%]
 <section class="related-products xs-hide sm-hide">
     <div class="related-products-area">
         <h4>You may also like</h4>
         <br>
-        <amp-list id="products-list" src="/api/related-products?categoryId=<%CategoryId%>&productId=<%Main_Id%>" height="140" width="auto" layout="fixed-height">
+        <amp-list id="products-list" src="/api/related-products?categoryId=[%CategoryId%]&productId=[%Main_Id%]" height="140" width="auto" layout="fixed-height">
             <template type="amp-mustache">
                 <amp-carousel height="170" layout="fixed-height" type="carousel">
                   {{#items}}
                     <ul>
                         <li>
-                            <a href="/product-details?categoryId=<%CategoryId%>&productId={{productId}}" class="text-decoration-none">
+                            <a href="/product-details?categoryId=[%CategoryId%]&productId={{productId}}" class="text-decoration-none">
                                 <amp-img src="{{image}}" width="1" height="1" layout="responsive" alt="{{name}}" noloading="">
                                     <div placeholder="" class="loading"></div>
                                 </amp-img>
@@ -23,4 +23,4 @@
         </amp-list>
     </div>
 </section>
-<%/Main_Id%>
+[%/Main_Id%]


### PR DESCRIPTION
* replace amphtml-autoscript with optimizer built-in functionality
* change template tags from <% to [% to avoid conflicts with the html
parsers
* move AMP Optimizer invocation to built-time instead of runtime
* let AMP Optimizer inject AMP mandatory tags