### PR TITLE
amp-camp: binding should be refresh for product listing

### DIFF
--- a/amp-camp/src/html/pages/product-listing.html
+++ b/amp-camp/src/html/pages/product-listing.html
@@ -86,7 +86,7 @@
                           src="/api/categories?categoryId=[%productsGender%]-[%productsCategory%]&sort=high-low"
                           height="1000" width="300"
                           layout="responsive"
-                          binding="no"
+                          binding="refresh"
                 >
                     <template type="amp-mustache">
                         <a href="product-details?categoryId=[%productsGender%]-[%productsCategory%]&productId={{productId}}"


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/25660

**Explanation**
The `<amp-list>` [binding](https://amp.dev/documentation/components/amp-list/#binding-(optional)) attribute is relatively confusing. By marking `binding=no`, the <amp-list> was declaring that each time the template is rerendered with from a new fetch it should not use the latest amp-state (it doesn't invoke amp-bind at all).

Whats really interesting in this case is that intuitively I would have expected it to work since I would have expected the `<template>` to be updated. From what I can tell, `<amp-bind>` doesn't update templates.

**Future work**
- Investigate why amp-bind isn't updating templates and maybe make it start 