### PR TITLE
Fix special character handling in amp-script tutorial

### DIFF
--- a/amp-script-tutorial/finished_code/js/validate.js
+++ b/amp-script-tutorial/finished_code/js/validate.js
@@ -8,7 +8,7 @@ const checkRegexes = {
   lower: /[a-z]/,
   upper: /[A-Z]/,
   digit: /\d/,
-  special: /[^a-z\d]/i,
+  special: /[^a-zA-Z\d]/i,
   eight: /.{8}/
 };
 

--- a/amp-script-tutorial/starter_code/index.html
+++ b/amp-script-tutorial/starter_code/index.html
@@ -119,7 +119,7 @@
                 required
                 role="input"
                 tabindex="2"
-                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-z\d]).{8,}$"
+                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{8,}$"
                 on="tap:rules.show; input-debounced:rules.show">
         </div>
         <div id="rules" hidden>


### PR DESCRIPTION
I inherited this from the earlier version, I think... a capital letter could pass as a special character due to an overly permissive regex.